### PR TITLE
Migrate to manifest v3

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -6,8 +6,14 @@ chrome.tabs.onUpdated.addListener(
      tab: chrome.tabs.Tab) => {
          if (changeInfo.status === 'complete') {
              if (CompaitoConfig.getConfig().isHostEnabled(tab.url)) {
-                 chrome.tabs.executeScript(tabId, { file: 'js/content.js' });
-                 chrome.tabs.insertCSS(tabId, { file: 'css/content.css' });
+                 chrome.scripting.executeScript({
+                     target: { tabId: tabId },
+                     files: ['js/content.js']
+                 });
+                 chrome.scripting.insertCSS({
+                     target: { tabId: tabId },
+                     files: ['css/content.css']
+                 });
              }
          }
      }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,11 +1,12 @@
 import { CompaitoConfig } from './components/CompaitoConfig';
 
 chrome.tabs.onUpdated.addListener(
-    (tabId: number,
+    async (tabId: number,
      changeInfo: chrome.tabs.TabChangeInfo,
      tab: chrome.tabs.Tab) => {
          if (changeInfo.status === 'complete') {
-             if (CompaitoConfig.getConfig().isHostEnabled(tab.url)) {
+             const config = await CompaitoConfig.getConfig();
+             if (config.isHostEnabled(tab.url)) {
                  chrome.scripting.executeScript({
                      target: { tabId: tabId },
                      files: ['js/content.js']

--- a/src/components/CompaitoConfig.ts
+++ b/src/components/CompaitoConfig.ts
@@ -10,8 +10,8 @@ class CompaitoConfig {
         this.data = data;
     }
 
-    save(): void {
-        CompaitoConfig.saveConfig(this.data);
+    save(): Promise<void> {
+        return CompaitoConfig.saveConfig(this.data);
     }
 
     // hosts
@@ -38,10 +38,11 @@ class CompaitoConfig {
         return { hosts: { 'github.com': true } };
     }
 
-    static getConfig(): CompaitoConfig {
+    static async getConfig(): Promise<CompaitoConfig> {
         let data: CompaitoConfigData;
         try {
-            data = JSON.parse(localStorage.getItem('compaito'))
+            const result = await chrome.storage.local.get('compaito');
+            data = result.compaito;
         } catch(e) {
             console.error(e.toString());
         };
@@ -49,8 +50,8 @@ class CompaitoConfig {
         return new CompaitoConfig(data);
     }
 
-    static saveConfig(data: CompaitoConfigData): void {
-        localStorage.setItem('compaito', JSON.stringify(data))
+    static saveConfig(data: CompaitoConfigData): Promise<void> {
+        return chrome.storage.local.set({ compaito: data });
     }
 
     static isHostsValid(hosts: any): boolean {

--- a/src/components/ConfigEditor.ts
+++ b/src/components/ConfigEditor.ts
@@ -19,10 +19,10 @@ class ConfigEditorPresenter extends Presenter {
         super(view);
         this.hasDiff  = false;
         this.hasSaved = false;
-        this.config   = CompaitoConfig.getConfig();
     }
 
-    setup(): void {
+    async setup(): Promise<void> {
+        this.config = await CompaitoConfig.getConfig();
         this.view.restoreHostConfigJson();
         this.view.updateButton();
     }
@@ -51,8 +51,8 @@ class ConfigEditorPresenter extends Presenter {
         this.view.updateButton();
     }
 
-    handleSave(): void {
-        this.config.save();
+    async handleSave(): Promise<void> {
+        await this.config.save();
         this.hasSaved = true;
         this.hasDiff  = false;
         this.view.updateButton();
@@ -83,8 +83,8 @@ class ConfigEditorView extends View implements IConfigEditorView {
         this.textarea.addEventListener('input', (e) => {
             this.presenter.handleHostConfigInput(this.textarea.value);
         });
-        this.saveButton.addEventListener('click', (e) => {
-            this.presenter.handleSave();
+        this.saveButton.addEventListener('click', async (e) => {
+            await this.presenter.handleSave();
         });
     }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,8 @@
     ],
     "permissions": [
         "tabs",
-        "scripting"
+        "scripting",
+        "storage"
     ],
     "icons": {
         "16":  "img/compaito16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,18 +1,19 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
 
     "name": "compaito",
     "version": "generate by 'manifesft' gulp task",
     "description": "",
 
     "background": {
-        "scripts": ["js/background.js"],
-        "persistent": false
+        "service_worker": "js/background.js"
     },
     "options_page": "html/options.html",
-    "permissions": [
+    "host_permissions": [
         "http://*/*",
-        "https://*/*",
+        "https://*/*"
+    ],
+    "permissions": [
         "tabs"
     ],
     "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,8 @@
         "https://*/*"
     ],
     "permissions": [
-        "tabs"
+        "tabs",
+        "scripting"
     ],
     "icons": {
         "16":  "img/compaito16.png",

--- a/test/CompaitoConfig.ts
+++ b/test/CompaitoConfig.ts
@@ -5,13 +5,13 @@ import { CompaitoConfig } from '../src/components/CompaitoConfig';
 describe('CompaitoConfig', () => {
     afterEach(() => { localStorage.clear() });
 
-    it('#getHosts', () => {
-        let config = CompaitoConfig.getConfig();
+    it('#getHosts', async () => {
+        let config = await CompaitoConfig.getConfig();
         assert.deepEqual(config.getHosts(), { 'github.com': true });
     });
 
-    it('#setHosts', () => {
-        let config = CompaitoConfig.getConfig();
+    it('#setHosts', async () => {
+        let config = await CompaitoConfig.getConfig();
         assert.throws(config.setHosts.bind(config, 'hoge'), 'Invalid hosts');
         assert.doesNotThrow(
             config.setHosts.bind(config, { 'github.com': true }),
@@ -19,8 +19,8 @@ describe('CompaitoConfig', () => {
         );
     });
 
-    it('#isHostEnabled', () => {
-        let config = CompaitoConfig.getConfig();
+    it('#isHostEnabled', async () => {
+        let config = await CompaitoConfig.getConfig();
         config.setHosts({
             'github.com': true,
             'my.ghe.com': true,
@@ -46,11 +46,11 @@ describe('CompaitoConfig', () => {
             );
         });
 
-        it('#getConfig', () => {
+        it('#getConfig', async () => {
             let error = sinon.stub(console, 'error');
 
             assert.deepEqual(
-                CompaitoConfig.getConfig().getHosts(),
+                (await CompaitoConfig.getConfig()).getHosts(),
                 { 'github.com': true },
                 'returns default'
             );
@@ -58,7 +58,7 @@ describe('CompaitoConfig', () => {
 
             localStorage.setItem('compaito', '{ invalidjson }');
             assert.deepEqual(
-                CompaitoConfig.getConfig().getHosts(),
+                (await CompaitoConfig.getConfig()).getHosts(),
                 { 'github.com': true },
                 'returns default with invalid'
             );
@@ -67,15 +67,15 @@ describe('CompaitoConfig', () => {
 
             localStorage.setItem('compaito', '{ "hosts": { "hoge": true } }');
             assert.deepEqual(
-                CompaitoConfig.getConfig().getHosts(),
+                (await CompaitoConfig.getConfig()).getHosts(),
                 { 'hoge': true },
                 'returns stored config'
             );
         });
 
-        it('#saveConfig', () => {
+        it('#saveConfig', async () => {
             assert.equal(localStorage.getItem('compaito'), null);
-            CompaitoConfig.saveConfig({ hosts: { 'my.ghe.com': true } });
+            await CompaitoConfig.saveConfig({ hosts: { 'my.ghe.com': true } });
             assert.equal(localStorage.getItem('compaito'), '{"hosts":{"my.ghe.com":true}}');
         });
 

--- a/test/ConfigEditor.ts
+++ b/test/ConfigEditor.ts
@@ -1,25 +1,26 @@
 /// <reference path="test.d.ts" />
 import * as sinon from 'sinon';
 import { IConfigEditorView, ConfigEditorPresenter, ConfigEditorView } from '../src/components/ConfigEditor'
+import { setupLocalStorageStub } from './LocalStorageStub';
 
 function createConfigEditoView(): IConfigEditorView {
     return {
-        restoreHostConfigJson(): void {},
-        updateButton(): void {},
-        updateError(): void{},
+        restoreHostConfigJson(): void { },
+        updateButton(): void { },
+        updateError(): void { },
     };
 }
 
 describe('ConfigEditorPresenter', () => {
-    afterEach(() => { localStorage.clear() });
+    setupLocalStorageStub();
 
-    it('basic flow', () => {
+    it('basic flow', async () => {
         let view = createConfigEditoView();
         let updateButton = sinon.spy(view, 'updateButton');
         let presenter = new ConfigEditorPresenter(view);
 
         assert.ok(updateButton.notCalled);
-        presenter.setup();
+        await presenter.setup();
         assert.equal(updateButton.callCount, 1);
         assert.equal(presenter.hasDiff, false);
         assert.equal(presenter.hasSaved, false);
@@ -40,7 +41,7 @@ describe('ConfigEditorPresenter', () => {
         assert.equal(presenter.isSaveButtonEnable, true);
         assert.equal(presenter.saveButtonText, 'Save');
 
-        presenter.handleSave();
+        await presenter.handleSave();
         assert.equal(updateButton.callCount, 4);
         assert.equal(presenter.hasDiff, false);
         assert.equal(presenter.hasSaved, true);
@@ -55,11 +56,11 @@ describe('ConfigEditorPresenter', () => {
         assert.equal(presenter.saveButtonText, 'Save');
     });
 
-    it('#hostsJson', () => {
+    it('#hostsJson', async () => {
         let view = createConfigEditoView();
         let presenter = new ConfigEditorPresenter(view);
 
-        presenter.setup();
+        await presenter.setup();
         assert.equal(presenter.hostsJson, '{\n  "github.com": true\n}');
 
         presenter.handleHostConfigInput('{ "isNotValidJson');
@@ -69,9 +70,9 @@ describe('ConfigEditorPresenter', () => {
         assert.equal(presenter.hostsJson, '{\n  "isValidJson": true\n}');
 
         // new instance
-        presenter.handleSave();
+        await presenter.handleSave();
         presenter = new ConfigEditorPresenter(view);
-        presenter.setup();
+        await presenter.setup();
         assert.equal(presenter.hostsJson, '{\n  "isValidJson": true\n}');
     });
 });

--- a/test/LocalStorageStub.ts
+++ b/test/LocalStorageStub.ts
@@ -1,0 +1,36 @@
+export class LocalStorageStub {
+    private storage: { [key: string]: any } = {};
+
+    async get(key: string): Promise<{ [key: string]: any }> {
+        if (key in this.storage) {
+            return { [key]: this.storage[key] };
+        }
+        return {};
+    }
+
+    async set(items: { [key: string]: any }): Promise<void> {
+        Object.assign(this.storage, items);
+    }
+
+    async clear(): Promise<void> {
+        this.storage = {};
+    }
+}
+
+export function setupLocalStorageStub(): LocalStorageStub {
+    const storageStub = new LocalStorageStub();
+
+    beforeEach(() => {
+        global.chrome = {
+            storage: {
+                local: storageStub,
+            },
+        } as any;
+    });
+
+    afterEach(() => {
+        storageStub.clear();
+    });
+
+    return storageStub;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
-        "rootDir": "src"
+        "rootDir": "."
     },
     "compileOnSave": false,
     "exclude": [ "node_modules" ]


### PR DESCRIPTION
I made minimal changes to support Manifest V3.

Working demonstration:
![manifest-v3-compaito](https://github.com/user-attachments/assets/36bad3e8-4789-4aed-ba0a-0e01848d3e12)

When testing, the design appears to be broken. However, in this pull request I only focused on supporting Manifest V3 and ensuring it loads on Chrome.

I plan to fix the design in the next pull request.