### PR TITLE
Fix design

### DIFF
--- a/src/content.less
+++ b/src/content.less
@@ -7,8 +7,8 @@
 @cancel-color:    #c0392b;
 
 @base-size: 10px;
-@v-padding: @base-size / 5;
-@h-padding: @base-size / 2;
+@v-padding: (@base-size / 5);
+@h-padding: (@base-size / 2);
 
 .chrome-extension-compaito {
     &.container {

--- a/src/content.less
+++ b/src/content.less
@@ -59,7 +59,7 @@
 
     .pick-prev {
         background-color: @pick-prev-color;
-        font-weigth: bold;
+        font-weight: bold;
         &:after { content: "~" };
     }
 


### PR DESCRIPTION
Without being enclosed in parentheses, the calculation was not performed and was output as is, resulting in no padding being set.
Also, I fixed a typo in font-weight.

Here is fixed design:
<img width="694" alt="image" src="https://github.com/user-attachments/assets/4c22d0ef-5b73-4768-a041-c339745c6d9a" />
